### PR TITLE
change order PublicProfile types to Profile type

### DIFF
--- a/src/graphql/typeDefs/dataTypes/extendedTypes/extended-profile.graphql
+++ b/src/graphql/typeDefs/dataTypes/extendedTypes/extended-profile.graphql
@@ -1,0 +1,3 @@
+extend type Profile @key(fields: "id") {
+  id: ID! @external
+}

--- a/src/graphql/typeDefs/dataTypes/order.graphql
+++ b/src/graphql/typeDefs/dataTypes/order.graphql
@@ -2,7 +2,7 @@ type Order @key(fields: "id") {
   "Unique id of the order"
   id: ID!
   "The member who placed this order"
-  member: PublicProfile!
+  member: Profile!
   "The event associated with this order"
   event: Event!
   "A partner associated with this order"
@@ -20,9 +20,9 @@ type Order @key(fields: "id") {
   "The date this order was last updated"
   lastUpdatedAt: Date!
   "The member who created this order"
-  createdBy: PublicProfile!
+  createdBy: Profile!
   "The member who last updated this order"
-  lastUpdatedBy: PublicProfile!
+  lastUpdatedBy: ID!
   "The checkout  mode used for this order with Stripe"
   stripeMode: String!
 }


### PR DESCRIPTION
Changes the profile types returned in an order from `PublicProfile` to `Profile`, since the only person who will view the order is the person who created it. 

The one exception is the `lastUpdatedBy` field which has been updated to ID type.  Since the order may be updated by staff we would not want to leak non-public fields. Keeping it PublicProfile means that we still couldn't show the name as the order record will not be returned by GraphQL Federation if the the member's profile is not public.