### PR TITLE
Write checkedInBy during checkin action

### DIFF
--- a/src/graphql/resolvers/queries/orderAllocation.js
+++ b/src/graphql/resolvers/queries/orderAllocation.js
@@ -29,5 +29,9 @@ export const fieldResolvers = {
       if (checkedInAt) isCheckedIn = true;
       return isCheckedIn;
     },
+    checkedInBy: ({ checkedInBy }, __, { dataSources: { memberLoader } }) => {
+      if (!checkedInBy) return null;
+      return memberLoader.load(checkedInBy);
+    },
   },
 };

--- a/src/graphql/resolvers/queries/publicOrderAllocation.js
+++ b/src/graphql/resolvers/queries/publicOrderAllocation.js
@@ -30,5 +30,9 @@ export const fieldResolvers = {
       if (checkedInAt) isCheckedIn = true;
       return isCheckedIn;
     },
+    checkedInBy: ({ checkedInBy }, __, { dataSources: { memberLoader } }) => {
+      if (!checkedInBy) return null;
+      return memberLoader.load(checkedInBy);
+    },
   },
 };

--- a/src/graphql/typeDefs/dataTypes/orderAllocation.graphql
+++ b/src/graphql/typeDefs/dataTypes/orderAllocation.graphql
@@ -16,6 +16,8 @@ type OrderAllocation {
   hasCheckedIn: Boolean!
   "The date/time allocatedTo person checked in"
   checkedInAt: Date
+  "Person who performed check-in"
+  checkedInBy: SecureProfile
   "Reference used by partners to allocate lead"
   partnerPin: String
   "Member who purchased this allocation"

--- a/src/graphql/typeDefs/dataTypes/publicOrderAllocation.graphql
+++ b/src/graphql/typeDefs/dataTypes/publicOrderAllocation.graphql
@@ -15,6 +15,8 @@ type PublicOrderAllocation {
   hasCheckedIn: Boolean!
   "The date/time allocatedTo person checked in"
   checkedInAt: Date
+  "Person who performed check-in"
+  checkedInBy: SecureProfile
   "Reference used by partners to allocate lead"
   partnerPin: String
   "Member who purchased this allocation"


### PR DESCRIPTION
Intentionally not removing checkedInBy when revertCheckin is called. Allows a bit of history until checkin is actually complete.