### PR TITLE
Add ability to safely delete products

### DIFF
--- a/src/dataSources/cloudFirestore/order.js
+++ b/src/dataSources/cloudFirestore/order.js
@@ -346,6 +346,15 @@ const order = dbInstance => {
     return batchWrite.commit().then(() => true);
   }
 
+  function orderAllocationCountWithProduct(productId) {
+    dlog('allocationCountWithProduct, %s', productId);
+    return allocationCollection
+      .where('product', '==', productId)
+      .select()
+      .get()
+      .then(querySnap => querySnap.size);
+  }
+
   return {
     get,
     getBatch,
@@ -361,6 +370,7 @@ const order = dbInstance => {
     findMeOrderAllocations,
     findMeOrderAllocationsForEvent,
     markMyAllocationsQuestionsComplete,
+    orderAllocationCountWithProduct,
   };
 };
 

--- a/src/dataSources/cloudFirestore/product.js
+++ b/src/dataSources/cloudFirestore/product.js
@@ -187,6 +187,11 @@ const product = dbInstance => {
     return null;
   }
 
+  function remove(productId) {
+    dlog('delete called on product %s', productId);
+    return productCollection.doc(productId).delete();
+  }
+
   return {
     get,
     getBatch,
@@ -195,6 +200,7 @@ const product = dbInstance => {
     update,
     validateSaleChecks,
     validateSale,
+    remove,
   };
 };
 

--- a/src/graphql/resolvers/mutations/product.js
+++ b/src/graphql/resolvers/mutations/product.js
@@ -1,4 +1,6 @@
 import debug from 'debug';
+import orderStore from '../../../dataSources/cloudFirestore/order';
+import productStore from '../../../dataSources/cloudFirestore/product';
 
 const dlog = debug('that:api:garbage:mutation:product');
 
@@ -7,6 +9,31 @@ export const fieldResolvers = {
     update: ({ productId }) => {
       dlog('update called for %s', productId);
       return { productId };
+    },
+    delete: async ({ productId }, __, { dataSources: { firestore } }) => {
+      dlog('delete called for product %s', productId);
+      const result = {
+        result: true,
+        message: 'ok',
+        productId,
+      };
+      const allocationCount = await orderStore(
+        firestore,
+      ).orderAllocationCountWithProduct(productId);
+      if (allocationCount > 0) {
+        result.result = false;
+        result.message = `Product ${productId} exists on order allocations. Cannot delete`;
+        return result;
+      }
+
+      const delResult = await productStore(firestore).remove(productId);
+      if (!delResult.writeTime) {
+        result.result = false;
+        result.message = `Product ${productId} failed, no write result received.`;
+        return result;
+      }
+
+      return result;
     },
   },
 };

--- a/src/graphql/typeDefs/dataTypes/enums/stripeCheckoutMode.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/stripeCheckoutMode.graphql
@@ -5,4 +5,6 @@ enum StripeCheckoutMode {
   SUBSCRIPTION
   "THAT Specific Code for generating Promotion Codes for coupons"
   COUPON
+  "THAT Specific Code for products processed by THAT Conference. E.g. Counselor Ticket"
+  THAT
 }

--- a/src/graphql/typeDefs/dataTypes/productDeleteResult.graphql
+++ b/src/graphql/typeDefs/dataTypes/productDeleteResult.graphql
@@ -1,0 +1,8 @@
+type ProductDeleteResult {
+  "Delete product result"
+  result: Boolean!
+  "Delete result message"
+  message: String!
+  "Id of product acted upon"
+  productId: ID!
+}

--- a/src/graphql/typeDefs/mutations/product.graphql
+++ b/src/graphql/typeDefs/mutations/product.graphql
@@ -1,4 +1,6 @@
 type ProductMutation {
   "update specific Product"
   update: ProductUpdate @auth(requires: "admin")
+  "Safe product delete. Will result false if any order allocation includes product"
+  delete: ProductDeleteResult!
 }


### PR DESCRIPTION
Safely deletes products by ensuring they where not used on any orders by validating they don't exist on any order allocations. 

Return result is:
```graphql
type ProductDeleteResult {
  "Delete product result"
  result: Boolean!
  "Delete result message"
  message: String!
  "Id of product acted upon"
  productId: ID!
}
```