### PR TITLE
add key field to interface ProductBase now that it's extended

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-garage",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "THAT Garage api. Where all the other stuff goes",
   "main": "index.js",
   "engines": {

--- a/src/graphql/typeDefs/dataTypes/interfaces/productBase.graphql
+++ b/src/graphql/typeDefs/dataTypes/interfaces/productBase.graphql
@@ -1,5 +1,5 @@
 "Base required fields for an product type"
-interface ProductBase {
+interface ProductBase @key(fields: "id") {
   "The unique id of the product"
   id: ID!
 


### PR DESCRIPTION
v2.11.0
It didn't to seem to make a difference in running the queries, but to keep things consistent adding a key field to interface type `ProductBase`.