### PR TITLE
Updates for working with allocation id's for notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-garage",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "THAT Garage api. Where all the other stuff goes",
   "main": "index.js",
   "engines": {

--- a/src/dataSources/cloudFirestore/order.js
+++ b/src/dataSources/cloudFirestore/order.js
@@ -256,20 +256,29 @@ const order = dbInstance => {
       );
   }
 
-  function findOrderAllocationsForEvent({ eventId }) {
-    dlog('findOrderAllocationsForEvent %s', eventId);
-    return allocationCollection
-      .where('event', '==', eventId)
-      .get()
-      .then(({ docs }) =>
-        docs.map(a => {
-          const r = {
-            id: a.id,
-            ...a.data(),
-          };
-          return allocationDateForge(r);
-        }),
-      );
+  function findOrderAllocationsForEvent({ eventId, enrollmentStatusFilter }) {
+    dlog(
+      'findOrderAllocationsForEvent %s, filter: %o',
+      eventId,
+      enrollmentStatusFilter,
+    );
+    let query = allocationCollection.where('event', '==', eventId);
+    if (
+      Array.isArray(enrollmentStatusFilter) &&
+      enrollmentStatusFilter?.length > 0
+    ) {
+      query = query.where('enrollmentStatus', 'in', enrollmentStatusFilter);
+    }
+
+    return query.get().then(({ docs }) =>
+      docs.map(a => {
+        const r = {
+          id: a.id,
+          ...a.data(),
+        };
+        return allocationDateForge(r);
+      }),
+    );
   }
 
   function findOrderAllocationForOrder({ orderId, orderAllocationId }) {

--- a/src/graphql/resolvers/queries/RegistrationOrderAllocation.js
+++ b/src/graphql/resolvers/queries/RegistrationOrderAllocation.js
@@ -32,5 +32,6 @@ export const fieldResolvers = {
       return memberLoader.load(checkedInBy);
     },
     receivedSwag: ({ receivedSwag }) => receivedSwag === true,
+    purchaseStatus: ({ purchaseStatus }) => purchaseStatus ?? 'COMPLETE',
   },
 };

--- a/src/graphql/resolvers/queries/eventAdmin.js
+++ b/src/graphql/resolvers/queries/eventAdmin.js
@@ -5,9 +5,17 @@ const dlog = debug('that:api:garage:query:eventAdmin');
 
 export const fieldResolvers = {
   EventAdminQuery: {
-    orderAllocations: ({ eventId }, __, { dataSources: { firestore } }) => {
+    orderAllocations: (
+      { eventId },
+      { filter },
+      { dataSources: { firestore } },
+    ) => {
       dlog('EventAdmin.orderAllocations called for event %s', eventId);
-      return orderStore(firestore).findOrderAllocationsForEvent({ eventId });
+      dlog('EventAdmin.orderAllocation filter # %O', filter);
+      return orderStore(firestore).findOrderAllocationsForEvent({
+        eventId,
+        enrollmentStatusFilter: filter,
+      });
     },
   },
 };

--- a/src/graphql/resolvers/queries/meOrder.js
+++ b/src/graphql/resolvers/queries/meOrder.js
@@ -37,5 +37,7 @@ export const fieldResolvers = {
     },
     // orders are all defaulted to 'REGUAR' type orders
     orderType: ({ orderType }) => orderType || 'REGULAR',
+    // old orders defaulted to 'COMPLETE' which would be null unless refuneded
+    status: ({ status }) => status ?? 'COMPLETE',
   },
 };

--- a/src/graphql/resolvers/queries/order.js
+++ b/src/graphql/resolvers/queries/order.js
@@ -32,5 +32,7 @@ export const fieldResolvers = {
     },
     // orders are all defaulted to 'REGULAR' type orders
     orderType: ({ orderType }) => orderType || 'REGULAR',
+    // old orders defaulted to 'COMPLETE' which would be null unless refuneded
+    status: ({ status }) => status ?? 'COMPLETE',
   },
 };

--- a/src/graphql/resolvers/queries/orderAllocation.js
+++ b/src/graphql/resolvers/queries/orderAllocation.js
@@ -31,5 +31,6 @@ export const fieldResolvers = {
       return memberLoader.load(checkedInBy);
     },
     receivedSwag: ({ receivedSwag }) => receivedSwag === true,
+    purchaseStatus: ({ purchaseStatus }) => purchaseStatus ?? 'COMPLETE',
   },
 };

--- a/src/graphql/resolvers/queries/publicOrderAllocation.js
+++ b/src/graphql/resolvers/queries/publicOrderAllocation.js
@@ -32,5 +32,6 @@ export const fieldResolvers = {
       return memberLoader.load(checkedInBy);
     },
     receivedSwag: ({ receivedSwag }) => receivedSwag === true,
+    purchaseStatus: ({ purchaseStatus }) => purchaseStatus ?? 'COMPLETE',
   },
 };

--- a/src/graphql/resolvers/queries/registrationOrder.js
+++ b/src/graphql/resolvers/queries/registrationOrder.js
@@ -26,5 +26,7 @@ export const fieldResolvers = {
       dlog('order allocations for an order: %s', orderId);
       return orderStore(firestore).findOrderAllocations({ orderId });
     },
+    // old orders defaulted to 'COMPLETE' which would be null unless refuneded
+    status: ({ status }) => status ?? 'COMPLETE',
   },
 };

--- a/src/graphql/typeDefs/dataTypes/enums/orderAllocationPurchaseStatus.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/orderAllocationPurchaseStatus.graphql
@@ -1,0 +1,11 @@
+"Purchase Status of Order Allocation"
+enum OrderAllocationPurchaseStatus {
+  "The order allocation purchase is complete"
+  COMPLETE
+  "The order allocation purchase has been refunded."
+  REFUNDED
+  "The order allocation purchase is cancelled, no funds returned. Usually with manual orders"
+  CANCELLED
+  "There is an error with the order allocation purchase and further investigation is required"
+  HAS_ERROR
+}

--- a/src/graphql/typeDefs/dataTypes/enums/orderPurchaseStatus.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/orderPurchaseStatus.graphql
@@ -1,0 +1,10 @@
+enum OrderPurchaseStatus {
+  "The order is complete"
+  COMPLETE
+  "The order has been refunded. It's allocations cannot be used"
+  REFUNDED
+  "The order is cancelled, no funds returned. Usually with manual orders"
+  CANCELLED
+  "There is an error with the order and further investigation is required"
+  HAS_ERROR
+}

--- a/src/graphql/typeDefs/dataTypes/extendedTypes/extend-EventAdminQuery.graphql
+++ b/src/graphql/typeDefs/dataTypes/extendedTypes/extend-EventAdminQuery.graphql
@@ -1,5 +1,10 @@
 extend type EventAdminQuery @key(fields: "eventId") {
   eventId: ID! @external
 
-  orderAllocations: [OrderAllocation]! @auth(requires: "admin")
+  """
+  Order Allocations associated with the Event.
+  filter: filter list of Order Allocations to included enum(s)
+  """
+  orderAllocations(filter: [EnrollmentStatus]): [OrderAllocation]!
+    @auth(requires: "event:admin:orderAllocations")
 }

--- a/src/graphql/typeDefs/dataTypes/meOrder.graphql
+++ b/src/graphql/typeDefs/dataTypes/meOrder.graphql
@@ -17,6 +17,8 @@ type MeOrder @key(fields: "id") {
   total: Float!
   "The amount discounted off of this order"
   amountDiscounted: Float!
+  "ENUM: The (purchase) status of this order"
+  status: OrderStatus!
   "The date this order was created"
   createdAt: Date!
   "The date this order was last updated"

--- a/src/graphql/typeDefs/dataTypes/order.graphql
+++ b/src/graphql/typeDefs/dataTypes/order.graphql
@@ -18,8 +18,8 @@ type Order @key(fields: "id") {
   total: Float!
   "The amount discounted off of this order"
   amountDiscounted: Float!
-  "The status of this order"
-  status: OrderStatus
+  "ENUM: The (purchase) status of this order"
+  status: OrderStatus!
   "The date this order was created"
   createdAt: Date!
   "The date this order was last updated"

--- a/src/graphql/typeDefs/dataTypes/orderAllocation.graphql
+++ b/src/graphql/typeDefs/dataTypes/orderAllocation.graphql
@@ -34,6 +34,12 @@ type OrderAllocation {
   receivedSwag: Boolean!
   "A UI managed field to keep track of product's enrollment status"
   enrollmentStatus: EnrollmentStatus
+  "ENUM: Reference for ui to align to specific event products"
+  uiReference: UiProductReference
+  "The most recent date a notification was sent for this orderAllocation"
+  notificationSentAt: Date
+  "ENUM: purchase status of this order allocation"
+  purchaseStatus: OrderAllocationPurchaseStatus
 
   # Question Responses
   """

--- a/src/graphql/typeDefs/dataTypes/publicOrderAllocation.graphql
+++ b/src/graphql/typeDefs/dataTypes/publicOrderAllocation.graphql
@@ -29,6 +29,8 @@ type PublicOrderAllocation {
   receivedSwag: Boolean!
   "A UI managed field to keep track of product's enrollment status"
   enrollmentStatus: EnrollmentStatus
+  "ENUM: purchase status of this order allocation"
+  purchaseStatus: OrderAllocationPurchaseStatus
 
   # Question Responses
   """

--- a/src/graphql/typeDefs/dataTypes/registrationOrder.graphql
+++ b/src/graphql/typeDefs/dataTypes/registrationOrder.graphql
@@ -24,6 +24,6 @@ type RegistrationOrder @key(fields: "id") {
   lastUpdatedBy: RegistrationProfile!
   "The checkout  mode used for this order with Stripe"
   stripeMode: String!
-  "Order status"
+  "ENUM: The (purchase) status of this order"
   status: OrderStatus!
 }

--- a/src/graphql/typeDefs/dataTypes/registrationOrderAllocation.graphql
+++ b/src/graphql/typeDefs/dataTypes/registrationOrderAllocation.graphql
@@ -29,6 +29,8 @@ type RegistrationOrderAllocation {
   receivedSwag: Boolean!
   "A UI managed field to keep track of product's enrollment status"
   enrollmentStatus: EnrollmentStatus
+  "ENUM: purchase status of this order allocation"
+  purchaseStatus: OrderAllocationPurchaseStatus
 
   # Question Responses
   """


### PR DESCRIPTION
v.2.14.0
Updates for working with allocation id's for notifications
Filtering on enrollmentStatus
Add new field purchaseStatus to order allocation used for refunds and cancelled tickets.
The equivelent field on an Order is `status`.
update field descriptions. some clean up.