### PR TITLE
Extends Event.Admin with  field `orders`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-garage",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "description": "THAT Garage api. Where all the other stuff goes",
   "main": "index.js",
   "engines": {

--- a/src/dataSources/cloudFirestore/order.js
+++ b/src/dataSources/cloudFirestore/order.js
@@ -113,6 +113,29 @@ const order = dbInstance => {
     };
   }
 
+  function findByEvent(eventId) {
+    dlog('finding orders for event %s', eventId);
+    return orderCollection
+      .where('event', '==', eventId)
+      .get()
+      .then(querySnap =>
+        querySnap.docs
+          .map(doc => {
+            const r = {
+              id: doc.id,
+              ...doc.data(),
+            };
+
+            return orderDateForge(r);
+          })
+          .sort((a, b) => {
+            if (a.orderDate.getTime() > b.orderDate.getTime()) return 1;
+            if (a.orderDate.getTime() < b.orderDate.getTime()) return -1;
+            return 0;
+          }),
+      );
+  }
+
   function getMe({ user, orderId }) {
     dlog(`get ${orderId} for user ${user.sub}`);
     return orderCollection
@@ -382,6 +405,7 @@ const order = dbInstance => {
     get,
     getBatch,
     getPaged,
+    findByEvent,
     getMe,
     getPagedMe,
     create,

--- a/src/graphql/resolvers/queries/eventAdmin.js
+++ b/src/graphql/resolvers/queries/eventAdmin.js
@@ -17,5 +17,9 @@ export const fieldResolvers = {
         enrollmentStatusFilter: filter,
       });
     },
+    orders: ({ eventId }, __, { dataSources: { firestore } }) => {
+      dlog('EventAdmin.orders called for event %s', eventId);
+      return orderStore(firestore).findByEvent(eventId);
+    },
   },
 };

--- a/src/graphql/typeDefs/dataTypes/extendedTypes/extend-EventAdminQuery.graphql
+++ b/src/graphql/typeDefs/dataTypes/extendedTypes/extend-EventAdminQuery.graphql
@@ -7,4 +7,7 @@ extend type EventAdminQuery @key(fields: "eventId") {
   """
   orderAllocations(filter: [EnrollmentStatus]): [OrderAllocation]!
     @auth(requires: "event:admin:orderAllocations")
+
+  "Orders placed for an event"
+  orders: [Order]!
 }


### PR DESCRIPTION
v2.16.0
Extends Event.Admin with `orders` field
Returns all orders for event.