### PR TITLE
add update of orders and allocations to REFUNDED or CANCELLED

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-garage",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "THAT Garage api. Where all the other stuff goes",
   "main": "index.js",
   "engines": {

--- a/src/graphql/resolvers/mutations/order.js
+++ b/src/graphql/resolvers/mutations/order.js
@@ -13,5 +13,21 @@ export const fieldResolvers = {
       dlog('OrderMutation, orderallocation called, %s', orderAllocationId);
       return { orderAllocationId };
     },
+    setRefunded: ({ orderId }, __, { dataSources: { firestore }, user }) => {
+      dlog('setRefunded called on order %s', orderId);
+      return orderStore(firestore).updateStatusOrderAndOrderAllocations({
+        orderId,
+        newStatus: 'REFUNDED',
+        user,
+      });
+    },
+    setCancelled: ({ orderId }, __, { dataSources: { firestore }, user }) => {
+      dlog('setCancelled called on order %s', orderId);
+      return orderStore(firestore).updateStatusOrderAndOrderAllocations({
+        orderId,
+        newStatus: 'CANCELLED',
+        user,
+      });
+    },
   },
 };

--- a/src/graphql/typeDefs/mutations/order.graphql
+++ b/src/graphql/typeDefs/mutations/order.graphql
@@ -5,4 +5,8 @@ type OrderMutation {
   "Mutations on Order Allocations attached to order"
   orderAllocation(orderAllocationId: ID!): OrderAllocationMutation
     @auth(requires: "admin")
+  "Set order and all associated order allocations as REFUNDED"
+  setRefunded: Order! @auth(requires: "admin")
+  "Set order and all associated order allocations as CANCELLED"
+  setCancelled: Order! @auth(requires: "admin")
 }


### PR DESCRIPTION
v2.18.0
add update of orders and allocations to REFUNDED or CANCELLED
Admin Mutation for order to update the order and its associated order allocations as Refunded or Cancelled. 