### PR TITLE
refactor batch calls to use Firestore.getAll()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-garage",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "THAT Garage api. Where all the other stuff goes",
   "main": "index.js",
   "engines": {

--- a/src/dataSources/cloudFirestore/order.js
+++ b/src/dataSources/cloudFirestore/order.js
@@ -60,8 +60,21 @@ const order = dbInstance => {
   function getBatch(ids) {
     if (!Array.isArray(ids))
       throw new Error('getBatch must receive an array of ids');
-    dlog('getBatch called %d ids', ids.length);
-    return Promise.all(ids.map(id => get(id)));
+    dlog('order getBatch called %d ids', ids.length);
+    const docRefs = ids.map(id => orderCollection.doc(id));
+    return dbInstance.getAll(...docRefs).then(docs =>
+      docs.map(doc => {
+        let result = null;
+        if (doc.exists) {
+          result = {
+            id: doc.id,
+            ...doc.data(),
+          };
+          result = orderDateForge(result);
+        }
+        return result;
+      }),
+    );
   }
 
   async function getPaged({ pageSize, cursor, eventId }) {

--- a/src/dataSources/cloudFirestore/product.js
+++ b/src/dataSources/cloudFirestore/product.js
@@ -47,10 +47,23 @@ const product = dbInstance => {
   }
 
   function getBatch(ids) {
-    dlog('getBatch called %d ids', ids.length);
     if (!Array.isArray(ids))
       throw new Error('getBatch must receive an array of ids');
-    return Promise.all(ids.map(id => get(id)));
+    dlog('product getBatch called %d ids', ids.length);
+    const docRefs = ids.map(id => productCollection.doc(id));
+    return dbInstance.getAll(...docRefs).then(docs =>
+      docs.map(doc => {
+        let result = null;
+        if (doc.exists) {
+          result = {
+            id: doc.id,
+            ...doc.data(),
+          };
+          result = productDateForge(result);
+        }
+        return result;
+      }),
+    );
   }
 
   async function getPaged({ pageSize, cursor }) {


### PR DESCRIPTION
v2.19.0
Refactors batch calls to use Firestore.getAll() over a Promise.all() of individual gets. 