### PR TITLE
Claimable tickets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4449,13 +4449,12 @@
       }
     },
     "node_modules/apollo-cache-control": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.14.0.tgz",
-      "integrity": "sha512-qN4BCq90egQrgNnTRMUHikLZZAprf3gbm8rC5Vwmc6ZdLolQ7bFsa769Hqi6Tq/lS31KLsXBLTOsRbfPHph12w==",
-      "deprecated": "The functionality provided by the `apollo-cache-control` package is built in to `apollo-server-core` starting with Apollo Server 3. See https://www.apollographql.com/docs/apollo-server/migration/#cachecontrol for details.",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.15.0.tgz",
+      "integrity": "sha512-U2uYvHZsWmR6s6CD5zlq3PepfbUAM8953CeVM2Y2QYMtJ8i4CYplEPbIWb3zTIXSPbIPeWGddM56pChI6Iz3zA==",
       "dependencies": {
-        "apollo-server-env": "^3.1.0",
-        "apollo-server-plugin-base": "^0.13.0"
+        "apollo-server-env": "^3.2.0",
+        "apollo-server-plugin-base": "^0.14.0"
       },
       "engines": {
         "node": ">=6.0"
@@ -4589,28 +4588,28 @@
       }
     },
     "node_modules/apollo-server-core": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.25.4.tgz",
-      "integrity": "sha512-1u3BnFKbCt6F9SPM7ZoWmtHK6ubme56H8hV5Mjv3KbfSairU76SU79IhO05BEJE57S6N+ddb1rm3Uk93X6YeGw==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.26.0.tgz",
+      "integrity": "sha512-z0dAZGu6zLhYLWVaRis6pR1dQbzPhA6xU5z0issR/sQR5kr466vFMF/rq//Jqwpd/A4xfTXZrFmr5urFyl4k4g==",
       "dependencies": {
         "@apollographql/apollo-tools": "^0.5.0",
         "@apollographql/graphql-playground-html": "1.6.27",
         "@apollographql/graphql-upload-8-fork": "^8.1.3",
         "@josephg/resolvable": "^1.0.0",
         "@types/ws": "^7.0.0",
-        "apollo-cache-control": "^0.14.0",
-        "apollo-datasource": "^0.9.0",
+        "apollo-cache-control": "^0.15.0",
+        "apollo-datasource": "^0.10.0",
         "apollo-graphql": "^0.9.0",
         "apollo-reporting-protobuf": "^0.8.0",
         "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.1.0",
+        "apollo-server-env": "^3.2.0",
         "apollo-server-errors": "^2.5.0",
-        "apollo-server-plugin-base": "^0.13.0",
-        "apollo-server-types": "^0.9.0",
-        "apollo-tracing": "^0.15.0",
+        "apollo-server-plugin-base": "^0.14.0",
+        "apollo-server-types": "^0.10.0",
+        "apollo-tracing": "^0.16.0",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.15.0",
+        "graphql-extensions": "^0.16.0",
         "graphql-tag": "^2.11.0",
         "graphql-tools": "^4.0.8",
         "loglevel": "^1.6.7",
@@ -4624,6 +4623,18 @@
       },
       "peerDependencies": {
         "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/apollo-server-core/node_modules/apollo-datasource": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.10.0.tgz",
+      "integrity": "sha512-wrLhuoM2MtA0KA0+3qyioe0H2FjAxjTvuFOlNCk6WberA887m0MQlWULZImCWTkKuN+zEAMerHfxN+F+W8+lBA==",
+      "dependencies": {
+        "apollo-server-caching": "^0.7.0",
+        "apollo-server-env": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/apollo-server-core/node_modules/apollo-graphql": {
@@ -4662,13 +4673,13 @@
       }
     },
     "node_modules/apollo-server-core/node_modules/apollo-server-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
-      "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
+      "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
       "dependencies": {
         "apollo-reporting-protobuf": "^0.8.0",
         "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.1.0"
+        "apollo-server-env": "^3.2.0"
       },
       "engines": {
         "node": ">=6"
@@ -4678,9 +4689,9 @@
       }
     },
     "node_modules/apollo-server-env": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
-      "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
+      "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
       "dependencies": {
         "node-fetch": "^2.6.1",
         "util.promisify": "^1.0.0"
@@ -4731,11 +4742,11 @@
       }
     },
     "node_modules/apollo-server-plugin-base": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.13.0.tgz",
-      "integrity": "sha512-L3TMmq2YE6BU6I4Tmgygmd0W55L+6XfD9137k+cWEBFu50vRY4Re+d+fL5WuPkk5xSPKd/PIaqzidu5V/zz8Kg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.14.0.tgz",
+      "integrity": "sha512-nTNSFuBhZURGjtWptdVqwemYUOdsvABj/GSKzeNvepiEubiv4N0rt4Gvy1inHDiMbo98wQTdF/7XohNcB9A77g==",
       "dependencies": {
-        "apollo-server-types": "^0.9.0"
+        "apollo-server-types": "^0.10.0"
       },
       "engines": {
         "node": ">=6"
@@ -4764,13 +4775,13 @@
       }
     },
     "node_modules/apollo-server-plugin-base/node_modules/apollo-server-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
-      "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
+      "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
       "dependencies": {
         "apollo-reporting-protobuf": "^0.8.0",
         "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.1.0"
+        "apollo-server-env": "^3.2.0"
       },
       "engines": {
         "node": ">=6"
@@ -4796,13 +4807,12 @@
       }
     },
     "node_modules/apollo-tracing": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.15.0.tgz",
-      "integrity": "sha512-UP0fztFvaZPHDhIB/J+qGuy6hWO4If069MGC98qVs0I8FICIGu4/8ykpX3X3K6RtaQ56EDAWKykCxFv4ScxMeA==",
-      "deprecated": "The `apollo-tracing` package is no longer part of Apollo Server 3. See https://www.apollographql.com/docs/apollo-server/migration/#tracing for details",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.16.0.tgz",
+      "integrity": "sha512-Oy8kTggB+fJ/hHXwHyMpuTl5KW7u1XetKFDErZVOobUKc2zjc/NgWiC/s7SGYZCgfLodBjvwfa6rMcvLkz7c0w==",
       "dependencies": {
-        "apollo-server-env": "^3.1.0",
-        "apollo-server-plugin-base": "^0.13.0"
+        "apollo-server-env": "^3.2.0",
+        "apollo-server-plugin-base": "^0.14.0"
       },
       "engines": {
         "node": ">=4.0"
@@ -8264,14 +8274,13 @@
       }
     },
     "node_modules/graphql-extensions": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.15.0.tgz",
-      "integrity": "sha512-bVddVO8YFJPwuACn+3pgmrEg6I8iBuYLuwvxiE+lcQQ7POotVZxm2rgGw0PvVYmWWf3DT7nTVDZ5ROh/ALp8mA==",
-      "deprecated": "The `graphql-extensions` API has been removed from Apollo Server 3. Use the plugin API instead: https://www.apollographql.com/docs/apollo-server/integrations/plugins/",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.16.0.tgz",
+      "integrity": "sha512-rZQc/USoEIw437BGRUwoHoLPR1LA791Ltj6axONqgKIyyx2sqIO3YT9kTbB/eIUdJBrCozp4KuUeZ09xKeQDxg==",
       "dependencies": {
         "@apollographql/apollo-tools": "^0.5.0",
-        "apollo-server-env": "^3.1.0",
-        "apollo-server-types": "^0.9.0"
+        "apollo-server-env": "^3.2.0",
+        "apollo-server-types": "^0.10.0"
       },
       "engines": {
         "node": ">=6.0"
@@ -8300,13 +8309,13 @@
       }
     },
     "node_modules/graphql-extensions/node_modules/apollo-server-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
-      "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
+      "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
       "dependencies": {
         "apollo-reporting-protobuf": "^0.8.0",
         "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.1.0"
+        "apollo-server-env": "^3.2.0"
       },
       "engines": {
         "node": ">=6"
@@ -18754,12 +18763,12 @@
       }
     },
     "apollo-cache-control": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.14.0.tgz",
-      "integrity": "sha512-qN4BCq90egQrgNnTRMUHikLZZAprf3gbm8rC5Vwmc6ZdLolQ7bFsa769Hqi6Tq/lS31KLsXBLTOsRbfPHph12w==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.15.0.tgz",
+      "integrity": "sha512-U2uYvHZsWmR6s6CD5zlq3PepfbUAM8953CeVM2Y2QYMtJ8i4CYplEPbIWb3zTIXSPbIPeWGddM56pChI6Iz3zA==",
       "requires": {
-        "apollo-server-env": "^3.1.0",
-        "apollo-server-plugin-base": "^0.13.0"
+        "apollo-server-env": "^3.2.0",
+        "apollo-server-plugin-base": "^0.14.0"
       }
     },
     "apollo-datasource": {
@@ -18864,28 +18873,28 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.25.4",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.25.4.tgz",
-      "integrity": "sha512-1u3BnFKbCt6F9SPM7ZoWmtHK6ubme56H8hV5Mjv3KbfSairU76SU79IhO05BEJE57S6N+ddb1rm3Uk93X6YeGw==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.26.0.tgz",
+      "integrity": "sha512-z0dAZGu6zLhYLWVaRis6pR1dQbzPhA6xU5z0issR/sQR5kr466vFMF/rq//Jqwpd/A4xfTXZrFmr5urFyl4k4g==",
       "requires": {
         "@apollographql/apollo-tools": "^0.5.0",
         "@apollographql/graphql-playground-html": "1.6.27",
         "@apollographql/graphql-upload-8-fork": "^8.1.3",
         "@josephg/resolvable": "^1.0.0",
         "@types/ws": "^7.0.0",
-        "apollo-cache-control": "^0.14.0",
-        "apollo-datasource": "^0.9.0",
+        "apollo-cache-control": "^0.15.0",
+        "apollo-datasource": "^0.10.0",
         "apollo-graphql": "^0.9.0",
         "apollo-reporting-protobuf": "^0.8.0",
         "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.1.0",
+        "apollo-server-env": "^3.2.0",
         "apollo-server-errors": "^2.5.0",
-        "apollo-server-plugin-base": "^0.13.0",
-        "apollo-server-types": "^0.9.0",
-        "apollo-tracing": "^0.15.0",
+        "apollo-server-plugin-base": "^0.14.0",
+        "apollo-server-types": "^0.10.0",
+        "apollo-tracing": "^0.16.0",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.15.0",
+        "graphql-extensions": "^0.16.0",
         "graphql-tag": "^2.11.0",
         "graphql-tools": "^4.0.8",
         "loglevel": "^1.6.7",
@@ -18895,6 +18904,15 @@
         "uuid": "^8.0.0"
       },
       "dependencies": {
+        "apollo-datasource": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.10.0.tgz",
+          "integrity": "sha512-wrLhuoM2MtA0KA0+3qyioe0H2FjAxjTvuFOlNCk6WberA887m0MQlWULZImCWTkKuN+zEAMerHfxN+F+W8+lBA==",
+          "requires": {
+            "apollo-server-caching": "^0.7.0",
+            "apollo-server-env": "^3.2.0"
+          }
+        },
         "apollo-graphql": {
           "version": "0.9.7",
           "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.7.tgz",
@@ -18922,21 +18940,21 @@
           }
         },
         "apollo-server-types": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
-          "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
+          "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
           "requires": {
             "apollo-reporting-protobuf": "^0.8.0",
             "apollo-server-caching": "^0.7.0",
-            "apollo-server-env": "^3.1.0"
+            "apollo-server-env": "^3.2.0"
           }
         }
       }
     },
     "apollo-server-env": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
-      "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
+      "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
       "requires": {
         "node-fetch": "^2.6.1",
         "util.promisify": "^1.0.0"
@@ -18973,11 +18991,11 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.13.0.tgz",
-      "integrity": "sha512-L3TMmq2YE6BU6I4Tmgygmd0W55L+6XfD9137k+cWEBFu50vRY4Re+d+fL5WuPkk5xSPKd/PIaqzidu5V/zz8Kg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.14.0.tgz",
+      "integrity": "sha512-nTNSFuBhZURGjtWptdVqwemYUOdsvABj/GSKzeNvepiEubiv4N0rt4Gvy1inHDiMbo98wQTdF/7XohNcB9A77g==",
       "requires": {
-        "apollo-server-types": "^0.9.0"
+        "apollo-server-types": "^0.10.0"
       },
       "dependencies": {
         "apollo-reporting-protobuf": {
@@ -18997,13 +19015,13 @@
           }
         },
         "apollo-server-types": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
-          "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
+          "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
           "requires": {
             "apollo-reporting-protobuf": "^0.8.0",
             "apollo-server-caching": "^0.7.0",
-            "apollo-server-env": "^3.1.0"
+            "apollo-server-env": "^3.2.0"
           }
         }
       }
@@ -19019,12 +19037,12 @@
       }
     },
     "apollo-tracing": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.15.0.tgz",
-      "integrity": "sha512-UP0fztFvaZPHDhIB/J+qGuy6hWO4If069MGC98qVs0I8FICIGu4/8ykpX3X3K6RtaQ56EDAWKykCxFv4ScxMeA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.16.0.tgz",
+      "integrity": "sha512-Oy8kTggB+fJ/hHXwHyMpuTl5KW7u1XetKFDErZVOobUKc2zjc/NgWiC/s7SGYZCgfLodBjvwfa6rMcvLkz7c0w==",
       "requires": {
-        "apollo-server-env": "^3.1.0",
-        "apollo-server-plugin-base": "^0.13.0"
+        "apollo-server-env": "^3.2.0",
+        "apollo-server-plugin-base": "^0.14.0"
       }
     },
     "apollo-utilities": {
@@ -21679,13 +21697,13 @@
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
     },
     "graphql-extensions": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.15.0.tgz",
-      "integrity": "sha512-bVddVO8YFJPwuACn+3pgmrEg6I8iBuYLuwvxiE+lcQQ7POotVZxm2rgGw0PvVYmWWf3DT7nTVDZ5ROh/ALp8mA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.16.0.tgz",
+      "integrity": "sha512-rZQc/USoEIw437BGRUwoHoLPR1LA791Ltj6axONqgKIyyx2sqIO3YT9kTbB/eIUdJBrCozp4KuUeZ09xKeQDxg==",
       "requires": {
         "@apollographql/apollo-tools": "^0.5.0",
-        "apollo-server-env": "^3.1.0",
-        "apollo-server-types": "^0.9.0"
+        "apollo-server-env": "^3.2.0",
+        "apollo-server-types": "^0.10.0"
       },
       "dependencies": {
         "apollo-reporting-protobuf": {
@@ -21705,13 +21723,13 @@
           }
         },
         "apollo-server-types": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
-          "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
+          "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
           "requires": {
             "apollo-reporting-protobuf": "^0.8.0",
             "apollo-server-caching": "^0.7.0",
-            "apollo-server-env": "^3.1.0"
+            "apollo-server-env": "^3.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-garage",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "THAT Garage api. Where all the other stuff goes",
   "main": "index.js",
   "engines": {

--- a/src/graphql/resolvers/mutations/meCheckouts.js
+++ b/src/graphql/resolvers/mutations/meCheckouts.js
@@ -1,6 +1,7 @@
 import debug from 'debug';
+import validateManualOrder from '../../../lib/that/validateManualOrder';
 
-const dlog = debug('that:api:garage:mutation:orders:meCheckout');
+const dlog = debug('that:api:garage:mutation:orders:meCheckouts');
 
 export const fieldResolvers = {
   MeCheckoutsMutation: {
@@ -8,5 +9,73 @@ export const fieldResolvers = {
       dlog('stripe called');
       return { memberId };
     },
+    claim: (
+      { memberId },
+      { claim },
+      { dataSources: { firestore, bouncerApi } },
+    ) => {
+      dlog('claim called by %s, order: %o', memberId, claim);
+      if (!claim.eventId) throw new Error('EventId is a required parameter');
+      if (!claim.productId)
+        throw new Error('ProductId is a required parameter');
+      // create that claim event to send to Bouncer
+      const now = new Date();
+      const thatClaimEvent = {
+        id: `thatev_clm_${now.toISOString()}`,
+        eventId: claim.eventId,
+        created: Math.floor(now.getTime() / 1000),
+        type: 'that.order.manual.created',
+        livemode: process.env.NODE_ENV === 'production',
+        order: {
+          // order object as needed by bouncer
+          member: memberId,
+          event: claim.eventId,
+          orderDate: now,
+          orderType: 'CLAIMABLE',
+          createdBy: memberId,
+          status: 'COMPLETE',
+          lineItems: [
+            {
+              productId: claim.productId ?? '',
+              quantity: 1,
+              isBulkPurchase: false,
+            },
+          ],
+        },
+      };
+      // validateClaimOrder
+      return validateManualOrder({
+        orderData: thatClaimEvent.order,
+        firestore,
+        isClaimOrder: true,
+      }).then(() =>
+        bouncerApi.postManualOrderEvent(thatClaimEvent).then(r => {
+          dlog('bouncer rest result:: %o', r);
+          return {
+            result: true,
+            message: 'Submitted. Check orders for product',
+          };
+        }),
+      );
+    },
   },
 };
+
+/*
+{
+	"order": {
+		"member": "auth0|5e5c7fbf11d8510d3c437187",
+		"event": "w1ZQFzsSZzRuItVCNVmC",
+		"orderDate": "2022-07-13T14:11:32.665Z",
+		"orderType": "REGULAR",
+		"total": 0,
+		"lineItems": [
+			{
+				"productId": "ZExYSrDqC2vW3ktfkxET",
+				"quantity": 7,
+				"isBulkPurchase": true
+			}
+		]
+	}
+}
+*/

--- a/src/graphql/resolvers/mutations/meOrders.js
+++ b/src/graphql/resolvers/mutations/meOrders.js
@@ -138,6 +138,7 @@ export const fieldResolvers = {
         };
       });
 
+      /* 
       // Add ON THAT ticket for speaker to give-away
       const onThatTicket = eventProducts.find(
         ep => ep.uiReference === 'VIRTUAL_CAMPER',
@@ -157,6 +158,7 @@ export const fieldResolvers = {
           );
         });
       }
+      */
 
       const now = new Date();
       const newOrderEvent = {

--- a/src/graphql/resolvers/queries/product.js
+++ b/src/graphql/resolvers/queries/product.js
@@ -22,6 +22,7 @@ export const fieldResolvers = {
     createdBy: ({ createdBy: id }) => ({ id }),
     lastUpdatedBy: ({ lastUpdatedBy: id }) => ({ id }),
     eventActivities: ({ eventActivities = [] }) => eventActivities,
+    isClaimable: ({ isClaimable }) => isClaimable ?? false,
   },
   Membership: {
     __resolveReference({ id }, { dataSources: { productLoader } }) {

--- a/src/graphql/typeDefs/dataTypes/MeClaimResult.graphql
+++ b/src/graphql/typeDefs/dataTypes/MeClaimResult.graphql
@@ -1,0 +1,4 @@
+type MeClaimResult {
+  result: Boolean!
+  message: String!
+}

--- a/src/graphql/typeDefs/dataTypes/enums/orderType.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/orderType.graphql
@@ -5,4 +5,6 @@ enum OrderType {
   SPEAKER
   "Partner order"
   PARTNER
+  "Claimable product order"
+  CLAIMABLE
 }

--- a/src/graphql/typeDefs/dataTypes/enums/uiProductReference.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/uiProductReference.graphql
@@ -27,8 +27,17 @@ enum UiProductReference {
   HOG_ROAST
   "Includes swag, e.g. t-shirt"
   SWAG
+  """
+  Claimable ticket for event. Can ONLY be checked out through checkout/claim
+  This product cannot be checked out with a strip product
+  """
+  CLAIMABLE_TICKET
+  "Virtual Camper promotional ticket"
   PROMO_VIRTUAL_CAMPER
+  "Camper NO FOOD promotional ticket"
   PROMO_CAMPER_NO_FOOD
+  "Camper promotional ticket"
   PROMO_CAMPER
+  "Everything Camper promotional ticket"
   PROMO_EVERYTHING_CAMPER
 }

--- a/src/graphql/typeDefs/dataTypes/inputs/ClaimOrderInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/ClaimOrderInput.graphql
@@ -1,0 +1,10 @@
+"Input value used for submitting a product claim"
+input ClaimOrderInput {
+  "The associated event"
+  eventId: ID!
+  """
+  The product to claim
+  Must be a 'claimable' product
+  """
+  productId: ID!
+}

--- a/src/graphql/typeDefs/dataTypes/inputs/couponInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/couponInput.graphql
@@ -26,7 +26,7 @@ input CouponCreateInput {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 }
 
@@ -58,6 +58,6 @@ input CouponUpdateInput {
   "Event this product is associated with"
   eventId: ID
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean
 }

--- a/src/graphql/typeDefs/dataTypes/inputs/familyInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/familyInput.graphql
@@ -26,7 +26,7 @@ input FamilyCreateInput {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"
@@ -61,7 +61,7 @@ input FamilyUpdateInput {
   "Event this product is associated with"
   eventId: ID
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/inputs/foodInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/foodInput.graphql
@@ -26,7 +26,7 @@ input FoodCreateInput {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"
@@ -61,7 +61,7 @@ input FoodUpdateInput {
   "Event this product is associated with"
   eventId: ID
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/inputs/membershipInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/membershipInput.graphql
@@ -26,7 +26,7 @@ input MembershipCreateInput {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"
@@ -64,7 +64,7 @@ input MembershipUpdateInput {
   "Event this product is associated with"
   eventId: ID
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/inputs/partnershipInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/partnershipInput.graphql
@@ -26,7 +26,7 @@ input PartnershipCreateInput {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"
@@ -61,7 +61,7 @@ input PartnershipUpdateInput {
   "Event this product is associated with"
   eventId: ID
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/inputs/ticketInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/ticketInput.graphql
@@ -26,11 +26,14 @@ input TicketCreateInput {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"
   eventActivities: [EventActivity]
+
+  "Product is claimable using the checkout claim mutation"
+  isClaimable: Boolean
 }
 
 input TicketUpdateInput {
@@ -61,9 +64,12 @@ input TicketUpdateInput {
   "Event this product is associated with"
   eventId: ID
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean
 
   "Event activities this product enables (enum)"
   eventActivities: [EventActivity]
+
+  "Product is claimable using the checkout claim mutation"
+  isClaimable: Boolean
 }

--- a/src/graphql/typeDefs/dataTypes/inputs/trainingInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/trainingInput.graphql
@@ -26,7 +26,7 @@ input TrainingCreateInput {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"
@@ -61,7 +61,7 @@ input TrainingUpdateInput {
   "Event this product is associated with"
   eventId: ID
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/interfaces/productBase.graphql
+++ b/src/graphql/typeDefs/dataTypes/interfaces/productBase.graphql
@@ -33,7 +33,7 @@ interface ProductBase @key(fields: "id") {
   "Event this product is associated with"
   eventId: ID
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/product/coupon.graphql
+++ b/src/graphql/typeDefs/dataTypes/product/coupon.graphql
@@ -30,7 +30,7 @@ type Coupon implements ProductBase @key(fields: "id") {
   "Reference to processor for associated product (Stripe, Shopify, etc.)"
   processor: ProcessorRef!
 
-  "Event this product is associated with"
+  "Is this product is enabled for use, sale, etc."
   eventId: ID!
 
   "This product is currently enabled"

--- a/src/graphql/typeDefs/dataTypes/product/family.graphql
+++ b/src/graphql/typeDefs/dataTypes/product/family.graphql
@@ -33,7 +33,7 @@ type Family implements ProductBase @key(fields: "id") {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/product/food.graphql
+++ b/src/graphql/typeDefs/dataTypes/product/food.graphql
@@ -33,7 +33,7 @@ type Food implements ProductBase @key(fields: "id") {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/product/membership.graphql
+++ b/src/graphql/typeDefs/dataTypes/product/membership.graphql
@@ -33,7 +33,7 @@ type Membership implements ProductBase @key(fields: "id") {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/product/partnership.graphql
+++ b/src/graphql/typeDefs/dataTypes/product/partnership.graphql
@@ -33,7 +33,7 @@ type Partnership implements ProductBase @key(fields: "id") {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/dataTypes/product/ticket.graphql
+++ b/src/graphql/typeDefs/dataTypes/product/ticket.graphql
@@ -33,7 +33,7 @@ type Ticket implements ProductBase @key(fields: "id") {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"
@@ -52,4 +52,6 @@ type Ticket implements ProductBase @key(fields: "id") {
   lastUpdatedBy: PublicProfile!
 
   # Ticket specific fields
+  "Product is claimable using the checkout claim mutation"
+  isClaimable: Boolean!
 }

--- a/src/graphql/typeDefs/dataTypes/product/training.graphql
+++ b/src/graphql/typeDefs/dataTypes/product/training.graphql
@@ -33,7 +33,7 @@ type Training implements ProductBase @key(fields: "id") {
   "Event this product is associated with"
   eventId: ID!
 
-  "This product is currently enabled"
+  "Is this product is enabled for use, sale, etc."
   isEnabled: Boolean!
 
   "Event activities this product enables (enum)"

--- a/src/graphql/typeDefs/mutations/meCheckouts.graphql
+++ b/src/graphql/typeDefs/mutations/meCheckouts.graphql
@@ -1,4 +1,6 @@
 type MeCheckoutsMutation {
   "Create a new checkout with Stripe"
   stripe: StripeCheckoutMutation @auth(requires: "members")
+  "Claim a claimable product"
+  claim(claim: ClaimOrderInput!): MeClaimResult! @auth(requires: "members")
 }

--- a/src/lib/that/__tests__/claimOrderChecks.test.js
+++ b/src/lib/that/__tests__/claimOrderChecks.test.js
@@ -1,0 +1,124 @@
+import claimOrderChecks from '../claimOrderChecks';
+
+const processorThat = {
+  checkoutMode: 'PAYMENT',
+  itemRefId: 'itemRef_a',
+  processor: 'THAT',
+};
+const processorThat2 = {
+  checkoutMode: 'THAT',
+  itemRefId: 'ItemRef_b',
+  processor: 'THAT',
+};
+const processorStripeP = {
+  checkoutMode: 'PAYMENT',
+  itemRefId: 'price_abc123',
+  processor: 'STRIPE',
+};
+const productsObj = [
+  {
+    id: 'productId_0',
+    name: 'test ticket product',
+    eventId: 'test_eventId',
+    isEnabled: true,
+    isClaimable: true,
+    uiReference: 'CLAIMABLE_TICKET',
+  },
+  {
+    id: 'productId_1',
+    name: 'test ticket product',
+    eventId: 'test_eventId',
+    isEnabled: true,
+    uiReference: 'CLAIMABLE_TICKET',
+  },
+];
+const productIdsObj = ['productId_0', 'productId_1'];
+const eventId = 'event_1';
+
+describe('claimORderChecks tests', () => {
+  let products;
+  let productIds;
+
+  beforeEach(() => {
+    products = [...productsObj];
+    products[0].processor = processorThat;
+    products[1].processor = processorThat2;
+    productIds = [...productIdsObj];
+  });
+  afterEach(() => {
+    products = null;
+    productIds = null;
+  });
+
+  describe('product settings and quantities are valid', () => {
+    describe('Only 1 product in the order', () => {
+      let result;
+      it('will be in error with more than 1 product', () => {
+        productIds.pop();
+        result = claimOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0]).toBe(`Claim orders must have exactly 1 line item`);
+      });
+      it('will be in error with more than 1 productIds', () => {
+        productIds.pop();
+        result = claimOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0]).toBe(`Claim orders must have exactly 1 line item`);
+      });
+      it('will be in error with no product', () => {
+        products = [];
+        productIds.pop();
+        result = claimOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0]).toBe(`Claim orders must have exactly 1 line item`);
+      });
+      it('will be in error with no productIds', () => {
+        products.pop();
+        productIds = [];
+        result = claimOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0]).toBe(`Claim orders must have exactly 1 line item`);
+      });
+      it('no set processor will error', () => {
+        products.pop();
+        productIds.pop();
+        delete products[0].processor;
+        result = claimOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0]).toBe(`Only THAT processed products can be claimed`);
+      });
+      it('will be in error with strip processor', () => {
+        products.pop();
+        productIds.pop();
+        products[0].processor = processorStripeP;
+        result = claimOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0]).toBe(`Only THAT processed products can be claimed`);
+      });
+    });
+    describe('Product must be claimable', () => {
+      let result;
+      it('will pass with 1 claimable product', () => {
+        products.pop();
+        productIds.pop();
+        result = claimOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBe(0);
+      });
+      it('will be in error with non-claimable product', () => {
+        products = [products[1]];
+        productIds = [productIds[1]];
+        result = claimOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBe(1);
+        expect(result[0]).toBe(`Product on order is not a claimable product`);
+      });
+      it('will have uiReference of CLAIMABLE_TICKET', () => {
+        products.pop();
+        productIds.pop();
+        products[0].uiReference = 'camper';
+        result = claimOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0]).toBe(`Product uiReference not CLAIMABLE_TICKET.`);
+      });
+    });
+  });
+});

--- a/src/lib/that/__tests__/manualOrderChecks.test.js
+++ b/src/lib/that/__tests__/manualOrderChecks.test.js
@@ -1,0 +1,86 @@
+import product from '../../../dataSources/cloudFirestore/product';
+import manualOrderChecks from '../manualOrderChecks';
+
+const productsObj = [
+  {
+    id: 'productId_0',
+    name: 'test ticket product',
+    eventId: 'test_eventId',
+    isEnabled: true,
+    isClaimable: true,
+  },
+  {
+    id: 'productId_1',
+    name: 'test ticket product',
+    eventId: 'test_eventId',
+    isEnabled: true,
+  },
+];
+const productIdsObj = ['productId_0', 'productId_1'];
+let eventId = 'test_eventId';
+
+describe('claimORderChecks tests', () => {
+  let products;
+  let productIds;
+
+  beforeEach(() => {
+    products = [...productsObj];
+    productIds = [...productIdsObj];
+  });
+  afterEach(() => {
+    products = null;
+    productIds = null;
+    eventId = 'test_eventId';
+  });
+
+  describe('prodcut settings and quantities are valid', () => {
+    describe('Valid product list passes', () => {
+      let result;
+      it('will pass with known good product list and matching ids', () => {
+        result = manualOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBe(0);
+      });
+    });
+    describe('product and id counts to match', () => {
+      let result;
+      it('will be in error if product < productIds length', () => {
+        products.pop();
+        result = manualOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0]).toBe(
+          `Not all products in manual order found in product collection`,
+        );
+      });
+      it('will be in error if product > productIds length', () => {
+        productIds.pop();
+        result = manualOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0]).toBe(
+          `Not all products in manual order found in product collection`,
+        );
+      });
+    });
+    describe('Products must be part of same event', () => {
+      let result;
+      it(`will be in error if event Id doesn't match`, () => {
+        eventId = 'someOtherEventId';
+        result = manualOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBe(1);
+        expect(result[0]).toBe(
+          `Product(s) in manual order which don't exist in eventId someOtherEventId`,
+        );
+      });
+    });
+    describe('Products cannot be of type MEMBERSHIP', () => {
+      let result;
+      it('will be in error with a membership product', () => {
+        products[0].type = 'MEMBERSHIP';
+        result = manualOrderChecks({ products, productIds, eventId });
+        expect(result.length).toBe(1);
+        expect(result[0]).toBe(
+          `'MEMBERSHIP' type products cannot be added to manual orders`,
+        );
+      });
+    });
+  });
+});

--- a/src/lib/that/claimOrderChecks.js
+++ b/src/lib/that/claimOrderChecks.js
@@ -1,0 +1,22 @@
+// order checks for claim orders
+// inclusive after manual order checks
+
+// eslint-disable-next-line no-unused-vars
+export default function claimOrderChecks({ products, productIds, eventId }) {
+  const errorList = [];
+
+  if (products.length !== 1 || productIds.length !== 1) {
+    errorList.push(`Claim orders must have exactly 1 line item`);
+  }
+  if (products.filter(p => p.isClaimable !== true).length > 0) {
+    errorList.push(`Product on order is not a claimable product`);
+  }
+  if (products.filter(p => p?.processor?.processor !== 'THAT').length > 0) {
+    errorList.push(`Only THAT processed products can be claimed`);
+  }
+  if (products.filter(p => p?.uiReference !== 'CLAIMABLE_TICKET').length > 0) {
+    errorList.push(`Product uiReference not CLAIMABLE_TICKET.`);
+  }
+
+  return errorList;
+}

--- a/src/lib/that/manualOrderChecks.js
+++ b/src/lib/that/manualOrderChecks.js
@@ -1,0 +1,30 @@
+// Order structure checks for manaual orders
+// not for claim orders
+
+export default function manualOrderChecks({
+  products = [],
+  productIds = [],
+  eventId,
+}) {
+  const errorList = [];
+
+  if (products.length !== productIds.length) {
+    errorList.push(
+      `Not all products in manual order found in product collection`,
+    );
+  }
+  if (
+    products.filter(p => p.eventId === eventId).length !== productIds.length
+  ) {
+    errorList.push(
+      `Product(s) in manual order which don't exist in eventId ${eventId}`,
+    );
+  }
+  if (products.filter(p => p.type === 'MEMBERSHIP').length > 0) {
+    errorList.push(
+      `'MEMBERSHIP' type products cannot be added to manual orders`,
+    );
+  }
+
+  return errorList;
+}

--- a/src/lib/that/validateManualOrder.js
+++ b/src/lib/that/validateManualOrder.js
@@ -1,11 +1,17 @@
 import debug from 'debug';
 import * as Sentry from '@sentry/node';
 import { dataSources } from '@thatconference/api';
+import manualOrderChecks from './manualOrderChecks';
+import claimOrderChecks from './claimOrderChecks';
 
 const dlog = debug('that:api:brinks:validateManualOrder');
 const productStoreFunc = dataSources.cloudFirestore.product;
 
-export default function validateManualOrder({ orderData, firestore }) {
+export default function validateManualOrder({
+  orderData,
+  firestore,
+  isClaimOrder = false,
+}) {
   dlog('validateManualOrder called');
   let eventId;
   let lineItems;
@@ -22,33 +28,43 @@ export default function validateManualOrder({ orderData, firestore }) {
 
   if (
     lineItems.filter(li => !li.isBulkPurchase && li.quantity !== 1).length > 0
-  )
-    throw new Error('Non-batch purchases must have a quantity of 1');
+  ) {
+    throw new Error('Non-batch purchase line items must have a quantity of 1');
+  }
+  if (isClaimOrder === true) {
+    if (lineItems.length !== 1) {
+      throw new Error('Claim orders must have exactly 1 line item');
+    }
+    if (lineItems[0].quantity !== 1) {
+      throw new Error('A claim order item must have a quantity of 1');
+    }
+  }
 
-  return productStore.getBatch(productIds).then(products => {
+  return productStore.getBatch(productIds).then(prods => {
+    const products = prods.filter(p => p !== null);
     const errorList = [];
-    if (products.length !== productIds.length) {
-      errorList.push(
-        `Not all products in manual order found in product collection`,
-      );
-    }
-    if (
-      products.filter(p => p.eventId === eventId).length !== productIds.length
-    ) {
-      errorList.push(
-        `Product(s) in manual order which don't exist in eventId ${eventId}`,
-      );
-    }
-    if (products.filter(p => p.type === 'MEMBERSHIP').length > 0) {
-      errorList.push(
-        `'MEMBERSHIP' type products cannot be added to manual orders`,
-      );
+
+    const moErrors = manualOrderChecks({
+      products,
+      productIds,
+      eventId,
+    });
+    errorList.push(...moErrors);
+
+    if (isClaimOrder === true) {
+      const coErrors = claimOrderChecks({
+        products,
+        productIds,
+        eventId,
+      });
+      errorList.push(...coErrors);
     }
 
     if (errorList.length > 0) {
       Sentry.setContext('products', { products });
       Sentry.setContext('order', { orderData });
-      Sentry.setContext('errors', errorList);
+      Sentry.setContext('errors', { errorList });
+      Sentry.setTag('isClaimOrder', isClaimOrder);
       const issueId = Sentry.captureException(
         new Error('Manual order validation failed', scope =>
           scope.setLevel('error'),


### PR DESCRIPTION
v2.21.0
depends on thatconference/that-api-events#186
- Adds claimable tickets
- Improved order and ticket validations across order types
- Removes speaker [give-away] virtual ticket add-on

Ticket claims done through mutation at: `orders/me/checkout/claim`
Products must have 
- `uiReference` type of `CLAIMABLE_TICKET`
- `processor` of `THAT`
- boolean `isClaimable` of `true`

Claim orders will only contain 1 line item. That item will have a quantity of 1.
