### PR TITLE
feat: add expo hall to event activity enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-garage",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "THAT Garage api. Where all the other stuff goes",
   "main": "index.js",
   "engines": {

--- a/src/graphql/typeDefs/dataTypes/enums/eventActivity.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/eventActivity.graphql
@@ -8,11 +8,18 @@ enum EventActivity {
   COUNSELOR_AT_THAT
   "Counselor presenting ON THAT Conference"
   COUNSELOR_ON_THAT
+  "Includes workshops"
   PRE_CONFERENCE
+  "Includes workshops"
   WORKSHOPS
   VIRTUAL_CAMPER
   ON_THE_LINE
+  "Includes Family track activities"
   FAMILY
+  "Includes a t-shirt"
   T_SHIRT
+  "Includes a hoodie"
   HOODIE
+  "Expo Hall only access"
+  EXPO_HALL
 }


### PR DESCRIPTION
v3.5.0
Adds `EXPO_HALL` to `eventActivities` enum