### PR TITLE
feat: add stripe checkout client_secret to return value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-garage",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "THAT Garage api. Where all the other stuff goes",
   "main": "index.js",
   "engines": {

--- a/src/graphql/resolvers/mutations/stripeCheckout.js
+++ b/src/graphql/resolvers/mutations/stripeCheckout.js
@@ -172,6 +172,7 @@ export const fieldResolvers = {
           returnResult.success = true;
           returnResult.message = 'success';
           returnResult.stripeCheckoutId = co.id;
+          returnResult.stripeClientSecret = co.client_secret ?? null;
           return returnResult;
         })
         .catch(err => {

--- a/src/graphql/typeDefs/dataTypes/stripeCheckoutResult.graphql
+++ b/src/graphql/typeDefs/dataTypes/stripeCheckoutResult.graphql
@@ -3,6 +3,8 @@ type StripeCheckoutResult {
   success: Boolean!
   "Informational message about the result"
   message: String!
-  "Strip Checkout ID to use for starting checkout process"
+  "Stripe Checkout ID to use for starting checkout process"
   stripeCheckoutId: String
+  "Stripe Checkout client_secret value for embedded checkouts"
+  stripeClientSecret: String
 }


### PR DESCRIPTION
## v4.4.0

minor version bump on schema changes

- Add stripe checkout `client_secret` on stripe checkout return value. null when not embedded checkout.