### PR TITLE
update that-api version to include graphcdn default change

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,6 @@
   },
   "peacock.affectActivityBar": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "that-api-garage",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "that-api-garage",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.2.2",
@@ -17,7 +17,7 @@
         "@graphql-tools/load-files": "^7.0.0",
         "@graphql-tools/merge": "^9.0.1",
         "@sentry/node": "~7.84.0",
-        "@thatconference/api": "^4.5.0",
+        "@thatconference/api": "^4.5.1",
         "@thatconference/schema": "^4.1.0",
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
@@ -3982,9 +3982,9 @@
       }
     },
     "node_modules/@thatconference/api": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-4.5.0.tgz",
-      "integrity": "sha512-K4mbZWZWQoJZNPrQSbT/VqiETVX5WzN0hp1oaCFtqpqadMAxquQtZV0GWliPp/ko400jkx515X6FoOiRcmu/zw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-4.5.1.tgz",
+      "integrity": "sha512-EJFO7iVIkRBf5pIbvzYjCO/SbuYZaWtsq+C12dnqgfdQ79us8+LP/Xg+546ATbAfLE2CWjz1qmHKmm7IK2uqXQ==",
       "dependencies": {
         "@adobe/node-fetch-retry": "^2.2.0",
         "@google-cloud/firestore": "^7.1.0",
@@ -16747,9 +16747,9 @@
       }
     },
     "@thatconference/api": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-4.5.0.tgz",
-      "integrity": "sha512-K4mbZWZWQoJZNPrQSbT/VqiETVX5WzN0hp1oaCFtqpqadMAxquQtZV0GWliPp/ko400jkx515X6FoOiRcmu/zw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-4.5.1.tgz",
+      "integrity": "sha512-EJFO7iVIkRBf5pIbvzYjCO/SbuYZaWtsq+C12dnqgfdQ79us8+LP/Xg+546ATbAfLE2CWjz1qmHKmm7IK2uqXQ==",
       "requires": {
         "@adobe/node-fetch-retry": "^2.2.0",
         "@google-cloud/firestore": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-garage",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "THAT Garage api. Where all the other stuff goes",
   "main": "index.js",
   "engines": {
@@ -28,7 +28,7 @@
     "@graphql-tools/load-files": "^7.0.0",
     "@graphql-tools/merge": "^9.0.1",
     "@sentry/node": "~7.84.0",
-    "@thatconference/api": "^4.5.0",
+    "@thatconference/api": "^4.5.1",
     "@thatconference/schema": "^4.1.0",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",


### PR DESCRIPTION
## v4.5.1

update that-api version to include graphcdn default change

Update was also made to production secrets for stellate URL reference